### PR TITLE
make ctx.validate types ignorable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,6 @@ declare module 'egg' {
   }
 
   export interface Context {
-    validate: (rules: any, data: any) => void;
+    validate: (rules: any, data?: any) => void;
   }
 }


### PR DESCRIPTION
把ctx.validate 的第二参数设置为可选，防止在typescript下不传该参数，无法通过编译的问题。